### PR TITLE
Add underscore to package.js.

### DIFF
--- a/package.js
+++ b/package.js
@@ -16,6 +16,7 @@ Package.onUse(function(api) {
     'coffeescript',
     'mongo',
     'random',
+    'underscore',
     'differential:cluster@1.0.1',
     'percolate:synced-cron@1.1.1',
     'underscorestring:underscore.string@3.2.2'


### PR DESCRIPTION
Need to add underscore in package.js with 1.2 - packages depending on differential:workers fail tests without it. 